### PR TITLE
[DIARY] 비행 일기 목록 조회

### DIFF
--- a/src/main/java/com/itprojectbackend/crew/service/CrewScheduleService.java
+++ b/src/main/java/com/itprojectbackend/crew/service/CrewScheduleService.java
@@ -178,6 +178,10 @@ public class CrewScheduleService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_CREW_SCHEDULE_ACCESS);
         }
 
+        FlightSchedule flightSchedule=crewSchedule.getFlightSchedule();
+        FlightDiary flightDiary=flightDiaryRepository.findByFlightSchedule(flightSchedule);
+
+        flightDiaryRepository.delete(flightDiary);
         crewScheduleRepository.delete(crewSchedule);
     }
 }

--- a/src/main/java/com/itprojectbackend/crew/service/CrewScheduleService.java
+++ b/src/main/java/com/itprojectbackend/crew/service/CrewScheduleService.java
@@ -10,6 +10,8 @@ import com.itprojectbackend.crew.dto.CrewScheduleResponse;
 import com.itprojectbackend.crew.repository.CrewScheduleRepository;
 import com.itprojectbackend.flight.domain.FlightSchedule;
 import com.itprojectbackend.flight.repository.FlightRepository;
+import com.itprojectbackend.flightdiary.domain.FlightDiary;
+import com.itprojectbackend.flightdiary.repository.FlightDiaryRepository;
 import com.itprojectbackend.user.UserFinder;
 import com.itprojectbackend.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class CrewScheduleService {
     private final AirportRepository airportRepository;
     private final FlightRepository flightRepository;
     private final UserFinder userFinder;
+    private final FlightDiaryRepository flightDiaryRepository;
 
     public List<CrewScheduleResponse> getScheduleByUserAndDay(Long userId, int year, int month, int day) {
         LocalDate targetDate=LocalDate.of(year, month, day);
@@ -126,8 +129,15 @@ public class CrewScheduleService {
                 .flightSchedule(flightSchedule)
                 .flightType(crewScheduleRequest.flightType())
                 .build();
-
         crewScheduleRepository.save(crewSchedule);
+
+        FlightDiary diary = FlightDiary.builder()
+                .flightSchedule(flightSchedule)
+                .writer(user)
+                .isWritten(false)
+                .build();
+
+        flightDiaryRepository.save(diary);
     }
 
     public List<CrewScheduleResponse> getScheduleList(Long userId) {

--- a/src/main/java/com/itprojectbackend/flightdiary/controller/FlightDiaryController.java
+++ b/src/main/java/com/itprojectbackend/flightdiary/controller/FlightDiaryController.java
@@ -1,5 +1,6 @@
 package com.itprojectbackend.flightdiary.controller;
 
+import com.itprojectbackend.flightdiary.dto.FlightDiaryListResponse;
 import com.itprojectbackend.flightdiary.dto.FlightDiaryRequest;
 import com.itprojectbackend.flightdiary.service.FlightDiaryService;
 import com.itprojectbackend.user.jwt.CustomUserDetails;
@@ -8,10 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/diaries")
@@ -27,5 +27,12 @@ public class FlightDiaryController {
         Long userId= customUserDetails.getUser().getId();
         flightDiaryService.writeFlightDiary(userId, flightDiaryRequest);
         return ResponseEntity.ok("비행 일기가 작성되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(summary = "비행 일기 조회", description = "해당 유저의 비행 일기를 조회하는 API입니다.")
+    public ResponseEntity<List<FlightDiaryListResponse>>getFlightDiaryList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long userId= customUserDetails.getUser().getId();
+        return ResponseEntity.ok(flightDiaryService.getFlightDiaryList(userId));
     }
 }

--- a/src/main/java/com/itprojectbackend/flightdiary/domain/FlightDiary.java
+++ b/src/main/java/com/itprojectbackend/flightdiary/domain/FlightDiary.java
@@ -6,12 +6,14 @@ import com.itprojectbackend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class FlightDiary extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,4 +31,7 @@ public class FlightDiary extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "flight_schedule_id")
     private FlightSchedule flightSchedule;
+
+    @Column(nullable = false)
+    private boolean isWritten;
 }

--- a/src/main/java/com/itprojectbackend/flightdiary/dto/FlightDiaryListResponse.java
+++ b/src/main/java/com/itprojectbackend/flightdiary/dto/FlightDiaryListResponse.java
@@ -1,0 +1,17 @@
+package com.itprojectbackend.flightdiary.dto;
+
+import com.itprojectbackend.flight.domain.enums.FlightType;
+import lombok.Builder;
+
+@Builder
+public record FlightDiaryListResponse(
+        Long diaryId,
+        String flightDate,
+        String departureCode,
+        String arrivalCode,
+        String flightNumber,
+        FlightType flightType,
+        boolean isWritten
+){
+
+}

--- a/src/main/java/com/itprojectbackend/flightdiary/repository/FlightDiaryRepository.java
+++ b/src/main/java/com/itprojectbackend/flightdiary/repository/FlightDiaryRepository.java
@@ -1,9 +1,13 @@
 package com.itprojectbackend.flightdiary.repository;
 
 import com.itprojectbackend.flightdiary.domain.FlightDiary;
+import com.itprojectbackend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FlightDiaryRepository extends JpaRepository<FlightDiary, Long> {
+    List<FlightDiary> findByWriter(User writer);
 }

--- a/src/main/java/com/itprojectbackend/flightdiary/repository/FlightDiaryRepository.java
+++ b/src/main/java/com/itprojectbackend/flightdiary/repository/FlightDiaryRepository.java
@@ -1,5 +1,6 @@
 package com.itprojectbackend.flightdiary.repository;
 
+import com.itprojectbackend.flight.domain.FlightSchedule;
 import com.itprojectbackend.flightdiary.domain.FlightDiary;
 import com.itprojectbackend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 @Repository
 public interface FlightDiaryRepository extends JpaRepository<FlightDiary, Long> {
     List<FlightDiary> findByWriter(User writer);
+
+    FlightDiary findByFlightSchedule(FlightSchedule flightSchedule);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #21 

## 📝작업 내용

> 해당 유저의 비행 일기 목록을 조회하는 API 구현

- 비행 스케줄에 대한 일기 작성 여부를 파악하기 위해 flightDiary 도메인에 isWritten 필드 추가했습니다.
- 비행 스케줄 추가, 삭제 시 flightDiary 설정 및 삭제 로직을 추가했습니다.

### 스크린샷
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/89959c17-dc98-4ebf-a9b0-cd76be23504b" />


